### PR TITLE
[wip] compute length of tar output for Content-Length

### DIFF
--- a/src/dirserver/main.go
+++ b/src/dirserver/main.go
@@ -17,7 +17,6 @@ import (
 	"sync"
 	"text/template"
 	"time"
-	"crypto/sha1"
 
 	ft "github.com/valyala/fasttemplate"
 	"golang.org/x/sys/unix"
@@ -34,7 +33,8 @@ type fsnode struct {
 	size   int64
 	fh     int32  // file handle
 	wd     int32  // watch descriptor, for inotify
-	etag   [sha1.Size]byte  // sha-1 hash of the tar of this directory
+	tarlength uint64  // size of the tar of this directory
+	ziplength uint64  // ditto for zip
 }
 
 type fsnamed struct {
@@ -933,6 +933,10 @@ func scanDir(n *fsnode) {
 				node:  nn,
 			})
 			n.chmap[fn] = nn
+			len := tarLength(nn, fn)
+			nn.tarlength = len
+			len = zipLength(nn, fn)
+			nn.ziplength = len
 		} else {
 			fmt.Fprintf(os.Stderr, "%q is unknown 0x%04X\n", fn, ft)
 			unix.Close(fh)

--- a/src/dirserver/tar.go
+++ b/src/dirserver/tar.go
@@ -7,21 +7,20 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"hash"
-	"hash/crc32"
-	"encoding/hex"
+	"strconv"
 
 	"golang.org/x/sys/unix"
 )
 
-func tarPack(twx *tar.Writer, nx *fsnode, dirpfxx string) {
+func tarPack(twx *tar.Writer, nx *fsnode, dirpfxx string, dummy bool) {
 	// place these in the outer scope so that they can be reused by recursive calls
 	var prevnodes []*fsnode
 	var hdr tar.Header
+	devzero := new(DevZero)
 
-	var packDirContents func(tw *tar.Writer, n *fsnode, dirpfx string)
+	var packDirContents func(tw *tar.Writer, n *fsnode, dirpfx string, dummy bool)
 
-	packDirContents = func(tw *tar.Writer, n *fsnode, dirpfx string) {
+	packDirContents = func(tw *tar.Writer, n *fsnode, dirpfx string, dummy bool) {
 		if n.fh < 0 {
 			panic("not directory")
 		}
@@ -59,7 +58,7 @@ func tarPack(twx *tar.Writer, nx *fsnode, dirpfxx string) {
 					}
 				}
 
-				packDirContents(tw, nn, fullname)
+				packDirContents(tw, nn, fullname, dummy)
 
 			loopdetected:
 				continue
@@ -67,149 +66,75 @@ func tarPack(twx *tar.Writer, nx *fsnode, dirpfxx string) {
 
 			hdr = tar.Header{Name: fullname, Mode: 0644}
 
-			const oflags = int(unix.O_RDONLY)
-			oh, errno := unix.Openat(int(fh), name, oflags, 0)
-			if oh < 0 || errno != nil {
-				// failed to open - skip
-				fmt.Fprintf(
-					os.Stderr,
-					"got error on openat %q: %v\n",
-					name, os.NewSyscallError("openat", errno))
-				continue
-			}
-
-			st := &unix.Stat_t{}
-			errno = unix.Fstat(oh, st)
-			if errno != nil {
-				unix.Close(oh)
-				fmt.Fprintf(
-					os.Stderr,
-					"failed to stat %q: %v\n",
-					name, os.NewSyscallError("fstatat", errno))
-				continue
-			}
-			hdr.ModTime = extractTime(st)
-			hdr.Size = st.Size
-
-			err := tw.WriteHeader(&hdr)
-			if err != nil {
-				unix.Close(oh)
-				panic("WriteHeader err: " + err.Error())
-			}
-
-			f := os.NewFile(uintptr(oh), "")
-			_, err = io.CopyN(tw, f, st.Size)
-			if err != nil {
-				f.Close()
-				panic("file copying failed: " + err.Error())
-			}
-			_ = f.Close()
-		}
-
-		prevnodes = prevnodes[:len(prevnodes)-1] // un-append
-	}
-
-	packDirContents(twx, nx, dirpfxx)
-}
-
-func tarDummyPack(twx *tar.Writer, nx *fsnode, dirpfxx string) {
-	// place these in the outer scope so that they can be reused by recursive calls
-	var prevnodes []*fsnode
-	var hdr tar.Header
-	devzero, err := os.Open("/dev/zero")
-	if err != nil {
-		panic(err)
-	}
-
-	var packDirContents func(tw *tar.Writer, n *fsnode, dirpfx string)
-
-	packDirContents = func(tw *tar.Writer, n *fsnode, dirpfx string) {
-		if n.fh < 0 {
-			panic("not directory")
-		}
-
-		prevnodes = append(prevnodes, n)
-
-		n.lock.RLock()
-		// copy 1 lvl of contents
-		chlist := make([]fsnamed, len(n.chlist))
-		copy(chlist, n.chlist)
-		updt := n.upd
-		n.lock.RUnlock()
-
-		if dirpfx != "" {
-			hdr = tar.Header{
-				Name:    dirpfx,
-				Mode:    0755,
-				ModTime: updt,
-			}
-			tw.WriteHeader(&hdr)
-		}
-
-		for i := range chlist {
-			nn := chlist[i].node
-			name := chlist[i].name
-			fullname := dirpfx + name
-
-			// directory
-			if nn.fh >= 0 {
-				// check for loop
-				for _, pn := range prevnodes {
-					if pn == nn {
-						goto loopdetected
-					}
+			if dummy {
+				hdr.ModTime = nn.upd
+				hdr.Size = nn.size
+				if hdr.Size == -1 {
+					hdr.Size = 0
 				}
 
-				packDirContents(tw, nn, fullname)
+				err := tw.WriteHeader(&hdr)
+				if err != nil {
+					panic("WriteHeader err: " + err.Error())
+				}
 
-			loopdetected:
-				continue
+				_, err = io.CopyN(tw, devzero, hdr.Size)
+				if err != nil {
+					panic("zeroing out failed: " + err.Error())
+				}
+			} else {
+				const oflags = int(unix.O_RDONLY)
+				oh, errno := unix.Openat(int(fh), name, oflags, 0)
+				if oh < 0 || errno != nil {
+					// failed to open - skip
+					fmt.Fprintf(
+						os.Stderr,
+						"got error on openat %q: %v\n",
+						name, os.NewSyscallError("openat", errno))
+					continue
+				}
+
+				st := &unix.Stat_t{}
+				errno = unix.Fstat(oh, st)
+				if errno != nil {
+					unix.Close(oh)
+					fmt.Fprintf(
+						os.Stderr,
+						"failed to stat %q: %v\n",
+						name, os.NewSyscallError("fstatat", errno))
+					continue
+				}
+				hdr.ModTime = extractTime(st)
+				hdr.Size = st.Size
+
+				err := tw.WriteHeader(&hdr)
+				if err != nil {
+					unix.Close(oh)
+					panic("WriteHeader err: " + err.Error())
+				}
+
+				f := os.NewFile(uintptr(oh), "")
+				_, err = io.CopyN(tw, f, st.Size)
+				if err != nil {
+					f.Close()
+					panic("file copying failed: " + err.Error())
+				}
+				_ = f.Close()
 			}
-
-			hdr = tar.Header{Name: fullname, Mode: 0644, ModTime: nn.upd, Size: nn.size}
-			if hdr.Size == -1 {
-				hdr.Size = 0
-			}
-
-			err := tw.WriteHeader(&hdr)
-			if err != nil {
-				panic("WriteHeader err: " + err.Error())
-			}
-
-			_, err = io.CopyN(tw, devzero, hdr.Size)
-			if err != nil {
-				panic("/dev/zero copying failed: " + err.Error())
-			}
-
 		}
 
 		prevnodes = prevnodes[:len(prevnodes)-1] // un-append
 	}
 
-	packDirContents(twx, nx, dirpfxx)
+	packDirContents(twx, nx, dirpfxx, dummy)
 }
 
-type sizedHash struct {
-	Hash hash.Hash
-	Len uint64
-}
-
-func (d *sizedHash) Write(b []byte) (int, error) {
-	count, err := d.Hash.Write(b)
-	if (err != nil) {
-		return 0, err
-	}
-	d.Len += uint64(count)
-	return count, nil
-}
-
-func tarHash(node *fsnode, next string) ([]byte, uint64) {
-	h := crc32.NewIEEE()
-	sized := new(sizedHash)
-	sized.Hash = h
-	tw := tar.NewWriter(sized)
-	tarDummyPack(tw, node, next)
-	return h.Sum(nil), sized.Len
+func tarLength(node *fsnode, next string) uint64 {
+	c := new(WriteCounter)
+	tw := tar.NewWriter(c)
+	tarPack(tw, node, next, true)
+	tw.Close()
+	return c.Len
 }
 
 func tarHandler(
@@ -235,6 +160,8 @@ func tarHandler(
 		return false
 	}
 
+	w.Header().Set("Content-Length", strconv.FormatUint(node.tarlength, 10))
+
 	tw := tar.NewWriter(w)
 
 	next = next[1:] // skip leading '/'
@@ -242,10 +169,7 @@ func tarHandler(
 		next += "/" // need trailing / to indicate dir
 	}
 
-	hash, size := tarHash(node, next)
-	fmt.Fprintf(os.Stderr, "tar dbg: %s %d %s\n", prev, size, hex.EncodeToString(hash))
-
-	tarPack(tw, node, next)
+	tarPack(tw, node, next, false)
 
 	tw.Close()
 

--- a/src/dirserver/tar.go
+++ b/src/dirserver/tar.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"crypto/sha1"
-	"encoding/hex"
 	"hash"
+	"hash/crc32"
+	"encoding/hex"
 
 	"golang.org/x/sys/unix"
 )
@@ -204,7 +204,7 @@ func (d *sizedHash) Write(b []byte) (int, error) {
 }
 
 func tarHash(node *fsnode, next string) ([]byte, uint64) {
-	h := sha1.New()
+	h := crc32.NewIEEE()
 	sized := new(sizedHash)
 	sized.Hash = h
 	tw := tar.NewWriter(sized)

--- a/src/dirserver/util.go
+++ b/src/dirserver/util.go
@@ -18,3 +18,18 @@ func unsafeStrToBytes(s string) []byte {
 func unsafeBytesToStr(b []byte) string {
 	return *(*string)(unsafe.Pointer(&b))
 }
+
+type WriteCounter struct {
+	Len uint64
+}
+
+func (c *WriteCounter) Write(b []byte) (int, error) {
+	c.Len += uint64(len(b))
+	return len(b), nil
+}
+
+type DevZero struct {}
+
+func (_ *DevZero) Read(p []byte) (int, error) {
+	return len(p), nil;
+}


### PR DESCRIPTION
running `bin/dirserver -http 127.0.0.1:5000 -root .` at the repo directory:

```
$ curl -s  http://dirserver.localhost:5000/src/dirserver/vendor/._tar/vendor.tar | wc -m
4965636
```

```
tar dbg: /src/dirserver/vendor 4964684 b0d631a26644098454369f090df91e019f63a3e5
```

they should both say 4965636.